### PR TITLE
bugfix(reopen) - curl use PUT

### DIFF
--- a/src/Command/CopyTabsCommand.php
+++ b/src/Command/CopyTabsCommand.php
@@ -260,7 +260,7 @@ class CopyTabsCommand extends Command implements EventSubscriberInterface
 
                     return sprintf('# %s', $title)
                         . PHP_EOL
-                        . sprintf("curl 'http://localhost:{$argumentPort}/json/new?%s'", $url)
+                        . sprintf("curl -X PUT 'http://localhost:{$argumentPort}/json/new?%s'", $url)
                         . PHP_EOL;
                 }, $jsonArray)
             );


### PR DESCRIPTION
Fixes: 
```
Using unsafe HTTP verb GET to invoke /json/new. This action supports only PUT verb
```

when running the reopen script